### PR TITLE
Remove "cordova.define" from the js file

### DIFF
--- a/www/AppleSignIn.js
+++ b/www/AppleSignIn.js
@@ -1,24 +1,22 @@
-cordova.define("cordova-plugin-applesignin.AppleSignIn", function(require, exports, module) {
 var exec = require('cordova/exec');
 var MODULE_NAME = "AppleSignIn";
 
 var promiseWrapper = function(method, theArgs = []) {
   return new Promise(function(resolve, reject) {
-      var success = function(state) { resolve(state) }
-      var failure = function(error) { reject(error) }
-      exec(success, failure, MODULE_NAME, method, theArgs);
+    var success = function(state) { resolve(state) }
+    var failure = function(error) { reject(error) }
+    exec(success, failure, MODULE_NAME, method, theArgs);
   });
 }
+
 exports.startLogin = function (userId = '') {
-    return promiseWrapper('startLogin', [userId]);
+  return promiseWrapper('startLogin', [userId]);
 };
 
 exports.isAvailable = function () {
   return promiseWrapper('isAvailable');
 };
                
- exports.isUserAuthorized = function (userId) {
-   return promiseWrapper('isUserAuthorized', [userId]);
- };
-
-});
+exports.isUserAuthorized = function (userId) {
+  return promiseWrapper('isUserAuthorized', [userId]);
+};


### PR DESCRIPTION
Cordova can auto generate "cordova.define" into the js file.
Remove the line of "cordova.define" to avoid Cordova plugin error: “Uncaught module … already defined”.